### PR TITLE
Introduce PublicProfile model and User-to-PublicProfile mapping to separate public and private user data

### DIFF
--- a/app/src/main/java/com/nathan/camistry/model/PublicProfile.kt
+++ b/app/src/main/java/com/nathan/camistry/model/PublicProfile.kt
@@ -1,0 +1,13 @@
+package com.nathan.camistry.model
+
+import android.location.Location
+
+class PublicProfile (
+    val id: String,
+    val firstName: String,
+    val age: Int,
+    val gender: String,
+    val location: Location,
+    val interests: List<String>,
+    val photos: List<String>
+)

--- a/app/src/main/java/com/nathan/camistry/model/User.kt
+++ b/app/src/main/java/com/nathan/camistry/model/User.kt
@@ -1,0 +1,16 @@
+package com.nathan.camistry.model
+
+import android.location.Location
+
+class User(
+    val id: String,
+    val firstName: String,
+    val lastName: String,
+    val age: Int,
+    val gender: String,
+    val location: Location,
+    val interests: List<String>,
+    val email: String,
+    val password: String,
+    val photos: List<String>
+)

--- a/app/src/main/java/com/nathan/camistry/util/UserExtensions.kt
+++ b/app/src/main/java/com/nathan/camistry/util/UserExtensions.kt
@@ -1,0 +1,16 @@
+package com.nathan.camistry.util
+
+import com.nathan.camistry.model.PublicProfile
+import com.nathan.camistry.model.User
+
+fun User.toPublicProfile(): PublicProfile {
+    return PublicProfile(
+        id = this.id,
+        firstName = this.firstName,
+        age = this.age,
+        gender = this.gender,
+        location = this.location,
+        interests = this.interests,
+        photos = this.photos
+    )
+}


### PR DESCRIPTION
This pull request introduces a new `PublicProfile` class, a `User` class, and an extension function to convert a `User` object into a `PublicProfile`. These changes aim to improve user data handling by separating public and private information.

### New classes for user data:

* [`app/src/main/java/com/nathan/camistry/model/PublicProfile.kt`](diffhunk://#diff-c8222d693875ce9f99dc76bce7982c56bf9fd168369fae5b8328d0822ee55a85R1-R13): Added a `PublicProfile` class to represent publicly visible user information, including `id`, `firstName`, `age`, `gender`, `location`, `interests`, and `photos`.
* [`app/src/main/java/com/nathan/camistry/model/User.kt`](diffhunk://#diff-4401a46561e382886a66bb81156f4daad5c7e13a5f96d763cd030d0938d62e62R1-R16): Added a `User` class to represent complete user information, including both public and private fields like `email` and `password`.

### Utility function for data transformation:

* [`app/src/main/java/com/nathan/camistry/util/UserExtensions.kt`](diffhunk://#diff-2ceb525674eb7c6482b55aee5cfd7e7fd4f326d20762f5a3e95fabc55742af5aR1-R16): Added an extension function `toPublicProfile()` for the `User` class to convert a `User` object into a `PublicProfile` object, ensuring private fields are excluded.