### PR TITLE
Merge into master: Update README.md, remove duplicate items from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# 🤝 Contributing to Camistry
+
+Thanks for your interest in contributing to **Camistry**,   
+We welcome contributions that help improve code quality, features, and user experience.
+
+---
+
+## 📦 Branching & Git Workflow
+
+We follow the **GitFlow** branching model:
+
+- Base all new work on the `develop` branch.
+- Use naming conventions:
+  - New features: `feature/your-feature-name`
+  - Bug fixes: `hotfix/your-fix-description`
+
+Pull requests should target the `develop` branch. The `master` branch is for production-ready code only and is protected.
+
+---
+
+## 🧪 Development Setup
+
+- Use **Android Studio** (latest stable version preferred)
+- **Min SDK:** 24  
+- **Target SDK:** 35 (subject to change)
+
+Firebase is used for authentication and Firestore. To run the project locally:
+
+### 🔥 Firebase Setup
+
+1. Create a new Firebase project in [Firebase Console](https://console.firebase.google.com/)
+2. Add an Android app to your Firebase project
+3. Download the `google-services.json` file
+4. Place it in:  
+   `app/google-services.json`
+
+Also update the `applicationId` in `app/build.gradle.kts` to your own id you just created:
+
+```kotlin
+applicationId = "com.example.camistryclone"
+```
+
+---
+
+## ✏️ Code Style Guidelines
+
+- Use tabs for indentation
+- camelCase for variable and method names
+- PascalCase for class names
+
+Keep code clean, readable, and well-structured. The project follows the MVC architecture:
+
+```
+├── ui/             // Activities & Fragments
+├── controller/     // Controllers
+├── repository/     // Data operations (Firebase, etc.)
+├── service/        // Services (Calculators, Generators, etc.)
+├── util/           // Reusable utils
+```
+
+---
+
+## ✅ Pull Request Requirements
+
+Before submitting a pull request:
+
+- Ensure your code compiles and runs correctly
+- Use descriptive commit messages and branch names
+- Include a video demonstration if the changes are visible in the app 
+  OR attach before/after screenshots
+- Optional: Add UnitTests for critical logic
+
+Here’s a sample checklist you can include in your PR description:
+
+### ✅ PR Checklist
+- [ ] Code compiles without errors
+- [ ] No hardcoded credentials or secrets
+- [ ] UI changes are shown in a video or screenshots
+- [ ] Branch is based on develop
+
+---
+
+## 📜 License
+
+All contributions to this project are subject to the terms of the  
+[LICENSE.md](./LICENSE.md) — **PolyForm Noncommercial License 1.0.0**
+
+> Contributions must be **noncommercial** in nature and comply with the license terms.
+
+---
+
+## 🙌 Final Notes
+
+Please open an **issue** before starting on a major change, or comment on an existing one if you'd like to take it on. We value communication and clarity — it helps the project move forward smoothly.
+
+Thank you for contributing to Camistry! ❤️

--- a/README.md
+++ b/README.md
@@ -57,44 +57,6 @@ Coming soon.
 
 ---
 
-## 🚀 Getting Started
-
-### 1. Clone the Repository
-
-```bash
-git clone https://github.com/NathanGrs00/camistry.git
-```
-
-### 2. Firebase Setup
-
-To run Camistry locally, you'll need your own Firebase project.
-
-1. Go to the [Firebase Console](https://console.firebase.google.com/)
-2. Create a new Firebase project
-3. Add an **Android app** to your project
-4. Download the `google-services.json` file
-5. Place the file in your project at:
-```
-app/google-services.json
-```
-
----
-
-### 3. Update `applicationId`
-
-To avoid build conflicts:
-
-1. Open `app/build.gradle.kts`
-2. Change the `applicationId` from:
-
-```kotlin
-applicationId = "com.nathan.camistry"
-```
-to the name you gave the project in the Firebase Console:
-```kotlin
-applicationId = "com.example.camistryclone"
-```
-
 ## 🧪 Development Notes
 
 - **Camistry** is **Android-only** for now. iOS may be considered in the future.
@@ -106,14 +68,8 @@ applicationId = "com.example.camistryclone"
 
 ## 🧑‍💻 Contributing
 
-We welcome contributions! Please follow these steps:
-
-1. **Open an issue** or comment on an existing one before starting work.
-2. **Fork** the repository.
-3. **Create a new branch** with a descriptive name.
-4. **Submit a pull request** with clear and concise commits.
-
-> 🔒 **Note:** Contributions must comply with the noncommercial licensing terms below.
+We welcome contributions!
+Please see the CONTRIBUTING.md file for contribution guidelines, coding style, and pull request requirements.
 
 ---
 


### PR DESCRIPTION
This pull request simplifies the `README.md` file by removing detailed setup instructions and contribution guidelines, instead directing users to external resources. The changes aim to streamline the documentation and reduce redundancy.

### Documentation Simplification:

* Removed the "Getting Started" section, which included detailed instructions for cloning the repository, setting up Firebase, and updating the `applicationId`. This reduces duplication and assumes users can refer to other resources for setup details.
* Updated the "Contributing" section to reference a new `CONTRIBUTING.md` file for contribution guidelines, coding style, and pull request requirements, instead of listing the steps directly in the `README.md`.