### PR TITLE
Merge into master: Fix LinkedIn link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Copyright © 2025 Nathan Geers
 For questions, feedback, or ideas, feel free to:
 
 - [Open an issue](../../issues) on GitHub  
-- Reach out on [LinkedIn](https://www.linkedin.com/in/your-linkedin-profile)
+- Reach out on [LinkedIn](https://www.linkedin.com/in/nathangeers/)
 
 ---


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file, correcting the LinkedIn profile link to point to the owners profile.